### PR TITLE
Streamline

### DIFF
--- a/bftgrid-core/src/lib.rs
+++ b/bftgrid-core/src/lib.rs
@@ -136,6 +136,27 @@ pub trait ActorSystem: Clone {
     ) where
         MsgT: ActorMsg,
         HandlerT: TypedHandler<MsgT = MsgT>;
+
+    fn spawn_async_send<MsgT, HandlerT, O>(
+        &self,
+        f: impl Future<Output = O> + Send + 'static,
+        to_msg: impl FnOnce(O) -> MsgT + Send + 'static,
+        actor_ref: AnActorRef<MsgT, HandlerT>,
+        delay: Option<Duration>,
+    ) where
+        MsgT: ActorMsg + 'static,
+        HandlerT: TypedHandler<MsgT = MsgT> + 'static;
+
+    fn spawn_blocking_send<MsgT, HandlerT, R>(
+        &self,
+        f: impl FnOnce() -> R + Send + 'static,
+        to_msg: impl FnOnce(R) -> MsgT + Send + 'static,
+        actor_ref: AnActorRef<MsgT, HandlerT>,
+        delay: Option<Duration>,
+    ) where
+        MsgT: ActorMsg + 'static,
+        HandlerT: TypedHandler<MsgT = MsgT> + 'static,
+        R: Send + 'static;
 }
 
 #[derive(Error, Debug, Clone)]

--- a/bftgrid-core/src/lib.rs
+++ b/bftgrid-core/src/lib.rs
@@ -151,7 +151,7 @@ pub enum P2PNetworkError {
 pub type P2PNetworkResult<R> = Result<R, P2PNetworkError>;
 
 /// A [`P2PNetwork`] allows sending messages to other nodes in a P2P network.
-pub trait P2PNetwork: Clone {
+pub trait P2PNetworkClient: Clone {
     fn attempt_send<MsgT, SerializerT>(
         &mut self,
         message: MsgT,

--- a/bftgrid-example/src/local.rs
+++ b/bftgrid-example/src/local.rs
@@ -110,12 +110,20 @@ where
                 None
             }
             1 => {
-                log::info!("Actor1 received second ping, self-pinging");
-                self.self_ref.send(Ping(), None);
+                log::info!("Actor1 received second ping, self-pinging after async work");
+                self.actor_system.spawn_async_send(
+                    async move {
+                        log::info!("Actor1 simulating async work");
+                    },
+                    |_| Ping(),
+                    self.self_ref.new_ref(),
+                    None,
+                );
                 None
             }
             _ => {
                 log::info!("Actor1 received third ping");
+                log::info!("Actor1 simulating async work");
                 if self.spawn_count < 1 {
                     log::info!("Actor1 spawning");
                     let mut new_ref = self.actor_system.create::<Ping, Actor1<ActorSystemT>>(

--- a/bftgrid-example/src/local.rs
+++ b/bftgrid-example/src/local.rs
@@ -205,7 +205,10 @@ where
     System::new(actor1_ref, actor2_ref)
 }
 
-fn main() {
+// Components that need a Tokio runtime will reuse the one from the async context, if any,
+//  otherwise they will create a new one.
+#[tokio::main]
+async fn main() {
     setup_logging();
     let thread_actor_system = ThreadActorSystem::new("thread-as");
     let tokio_actor_system = TokioActorSystem::new("tokio-as");

--- a/bftgrid-example/src/network.rs
+++ b/bftgrid-example/src/network.rs
@@ -2,12 +2,12 @@ use std::any::Any;
 
 use bftgrid_core::{
     ActorControl, ActorMsg, ActorRef, ActorSystem, AnActorMsg, AnActorRef, Joinable,
-    MessageNotSupported, P2PNetwork, TypedHandler, UntypedHandler,
+    MessageNotSupported, P2PNetworkClient, TypedHandler, UntypedHandler,
 };
 
 use bftgrid_example::setup_logging;
 use bftgrid_mt::{
-    new_tokio_runtime,
+    get_tokio_runtime,
     thread::ThreadActorSystem,
     tokio::{TokioActorSystem, TokioP2PNetworkClient, TokioP2PNetworkServer},
 };
@@ -21,7 +21,7 @@ impl ActorMsg for Ping {}
 struct Actor1<ActorSystemT, P2PNetworkT>
 where
     ActorSystemT: ActorSystem + 'static,
-    P2PNetworkT: P2PNetwork,
+    P2PNetworkT: P2PNetworkClient,
 {
     self_ref: AnActorRef<Ping, Actor1<ActorSystemT, P2PNetworkT>>,
     node_id: String,
@@ -34,7 +34,7 @@ where
 impl<ActorSystemT, P2PNetworkT> Actor1<ActorSystemT, P2PNetworkT>
 where
     ActorSystemT: ActorSystem,
-    P2PNetworkT: P2PNetwork,
+    P2PNetworkT: P2PNetworkClient,
 {
     fn new(
         self_ref: AnActorRef<Ping, Actor1<ActorSystemT, P2PNetworkT>>,
@@ -56,7 +56,7 @@ where
 impl<ActorSystemT, P2PNetworkT> TypedHandler for Actor1<ActorSystemT, P2PNetworkT>
 where
     ActorSystemT: ActorSystem + Send + std::fmt::Debug + 'static,
-    P2PNetworkT: P2PNetwork + Send + std::fmt::Debug + 'static,
+    P2PNetworkT: P2PNetworkClient + Send + std::fmt::Debug + 'static,
 {
     type MsgT = Ping;
 
@@ -70,10 +70,7 @@ where
                 None
             }
             1 => {
-                log::info!("Actor1 received second ping, sending second ping to Actor2 over the network and self-pinging");
-                let mut out = self.network_out.clone();
-                let _ = out.attempt_send(Ping {}, &|_msg| Ok(Vec::new()), "localhost:5002");
-                log::info!("Actor1 sent ping to Actor2 over the network, self-pinging");
+                log::info!("Actor1 received second ping, self-pinging");
                 self.self_ref.send(Ping(), None);
                 log::info!("Actor1 self-pinged");
                 None
@@ -116,49 +113,32 @@ where
 #[derive(Debug)]
 struct Actor2<P2PNetworkT>
 where
-    P2PNetworkT: P2PNetwork,
+    P2PNetworkT: P2PNetworkClient,
 {
     network_out: P2PNetworkT,
-    ping_count: u8,
 }
 
 impl<P2PNetworkT> Actor2<P2PNetworkT>
 where
-    P2PNetworkT: P2PNetwork,
+    P2PNetworkT: P2PNetworkClient,
 {
     fn new(network_out: P2PNetworkT) -> Self {
-        Actor2 {
-            network_out,
-            ping_count: 0,
-        }
+        Actor2 { network_out }
     }
 }
 
 impl<P2PNetworkT> TypedHandler for Actor2<P2PNetworkT>
 where
-    P2PNetworkT: P2PNetwork + Send + std::fmt::Debug + 'static,
+    P2PNetworkT: P2PNetworkClient + Send + std::fmt::Debug + 'static,
 {
     type MsgT = Ping;
 
     fn receive(&mut self, msg: Self::MsgT) -> Option<ActorControl> {
-        let ret = match self.ping_count {
-            0 => {
-                log::info!(
-                    "Actor2 received ping over the network, replying with a ping over the network"
-                );
-                let mut out = self.network_out.clone();
-                let _ = out.attempt_send(msg, &|_msg| Ok(Vec::new()), "localhost:5001");
-                // We expect in this example that sends are successful (although that's not generally the case);
-                //  for this reason we don't exit just after a network send, else it may not complete.
-                None
-            }
-            _ => {
-                log::info!("Actor2 received second ping, exiting");
-                Some(ActorControl::Exit())
-            }
-        };
-        self.ping_count += 1;
-        ret
+        log::info!("Actor2 received ping over the network, replying with a ping over the network");
+        let mut out = self.network_out.clone();
+        let _ = out.attempt_send(msg, &|_msg| Ok(Vec::new()), "localhost:5001");
+        log::info!("Actor2 sent ping reply, exiting");
+        Some(ActorControl::Exit())
     }
 }
 
@@ -166,7 +146,7 @@ where
 struct Node1P2pNetworkInputHandler<ActorSystemT, P2PNetworkT>
 where
     ActorSystemT: ActorSystem + 'static,
-    P2PNetworkT: P2PNetwork,
+    P2PNetworkT: P2PNetworkClient,
 {
     actor1_ref: AnActorRef<Ping, Actor1<ActorSystemT, P2PNetworkT>>,
 }
@@ -175,7 +155,7 @@ impl<ActorSystemT, P2PNetworkT> UntypedHandler
     for Node1P2pNetworkInputHandler<ActorSystemT, P2PNetworkT>
 where
     ActorSystemT: ActorSystem + std::fmt::Debug + Send + 'static,
-    P2PNetworkT: P2PNetwork + std::fmt::Debug + Send + 'static,
+    P2PNetworkT: P2PNetworkClient + std::fmt::Debug + Send + 'static,
 {
     fn receive_untyped(
         &mut self,
@@ -194,14 +174,14 @@ where
 #[derive(Debug)]
 struct Node2P2pNetworkInputHandler<P2PNetworkT>
 where
-    P2PNetworkT: P2PNetwork,
+    P2PNetworkT: P2PNetworkClient,
 {
     actor2_ref: AnActorRef<Ping, Actor2<P2PNetworkT>>,
 }
 
 impl<P2PNetworkT> UntypedHandler for Node2P2pNetworkInputHandler<P2PNetworkT>
 where
-    P2PNetworkT: P2PNetwork + std::fmt::Debug + Send + 'static,
+    P2PNetworkT: P2PNetworkClient + std::fmt::Debug + Send + 'static,
 {
     fn receive_untyped(
         &mut self,
@@ -217,9 +197,12 @@ where
     }
 }
 
-fn main() {
+// Components that need a Tokio runtime will reuse the one from the async context, if any,
+//  otherwise they will create a new one.
+#[tokio::main]
+async fn main() {
     setup_logging();
-    let runtime = new_tokio_runtime("main");
+    let runtime = get_tokio_runtime("main");
     let network1 = TokioP2PNetworkClient::new("network1", vec!["localhost:5002"]);
     let network2 = TokioP2PNetworkClient::new("network2", vec!["localhost:5001"]);
     let mut tokio_actor_system = TokioActorSystem::new("tokio-as");
@@ -239,7 +222,7 @@ fn main() {
     thread_actor_system.set_handler(&mut actor2_ref, Actor2::new(network2.clone()));
     let node1 = TokioP2PNetworkServer::new(
         "node1",
-        runtime.underlying.block_on(async {
+        runtime.await_async(async {
             UdpSocket::bind("localhost:5001")
                 .await
                 .expect("Cannot bind")
@@ -257,7 +240,7 @@ fn main() {
     log::info!("Started node1");
     let node2 = TokioP2PNetworkServer::new(
         "node2",
-        runtime.underlying.block_on(async {
+        runtime.await_async(async {
             UdpSocket::bind("localhost:5002")
                 .await
                 .expect("Cannot bind")
@@ -274,8 +257,9 @@ fn main() {
         .unwrap();
     log::info!("Started node2");
     actor1_ref.send(Ping(), None);
-    log::info!("Sent ping to actor1; joining actors, stopping servers and joining actor systems");
-    log::info!("Joined node2");
+    log::info!(
+        "Sent startup ping to actor1; joining actors, stopping servers and joining actor systems"
+    );
     actor2_ref.join();
     log::info!("Joined Actor2");
     actor1_ref.join();

--- a/bftgrid-mt/src/lib.rs
+++ b/bftgrid-mt/src/lib.rs
@@ -1,9 +1,10 @@
 use std::{
     future::Future,
     sync::{Arc, Condvar, Mutex},
+    time::Duration,
 };
 
-use bftgrid_core::Task;
+use bftgrid_core::{ActorMsg, AnActorRef, Task, TypedHandler};
 
 pub mod thread;
 pub mod tokio;
@@ -15,14 +16,14 @@ enum TokioRuntimeOrHandle {
 }
 
 #[derive(Debug)]
-pub struct TokioRuntime {
+pub struct AsyncRuntime {
     pub name: Arc<String>,
-    value: TokioRuntimeOrHandle,
+    tokio: TokioRuntimeOrHandle,
 }
 
 /// Unified interface for awaiting both async tasks and thread-blocking tasks
 /// from any context.
-impl TokioRuntime {
+impl AsyncRuntime {
     pub fn await_async<R>(&self, f: impl Future<Output = R>) -> R {
         match ::tokio::runtime::Handle::try_current() {
             Ok(handle) => {
@@ -38,11 +39,24 @@ impl TokioRuntime {
                     "Tokio runtime '{}' blocking on async outside of an async context",
                     self.name,
                 );
-                match &self.value {
+                match &self.tokio {
                     TokioRuntimeOrHandle::Runtime(runtime) => runtime.block_on(f),
                     TokioRuntimeOrHandle::Handle(handle) => handle.block_on(f),
                 }
             }
+        }
+    }
+
+    pub fn spawn_async<R>(
+        &self,
+        f: impl Future<Output = R> + Send + 'static,
+    ) -> ::tokio::task::JoinHandle<R>
+    where
+        R: Send + 'static,
+    {
+        match &self.tokio {
+            TokioRuntimeOrHandle::Runtime(runtime) => runtime.spawn(f),
+            TokioRuntimeOrHandle::Handle(handle) => handle.spawn(f),
         }
     }
 
@@ -66,16 +80,62 @@ impl TokioRuntime {
         }
     }
 
-    pub fn spawn<R>(
+    pub fn spawn_async_send<MsgT, HandlerT, O>(
         &self,
-        f: impl Future<Output = R> + Send + 'static,
-    ) -> ::tokio::task::JoinHandle<R>
-    where
+        f: impl Future<Output = O> + Send + 'static,
+        to_msg: impl FnOnce(O) -> MsgT + Send + 'static,
+        mut actor_ref: AnActorRef<MsgT, HandlerT>,
+        delay: Option<Duration>,
+    ) where
+        MsgT: ActorMsg + 'static,
+        HandlerT: TypedHandler<MsgT = MsgT> + 'static,
+    {
+        match &self.tokio {
+            TokioRuntimeOrHandle::Runtime(runtime) => runtime.spawn(async move {
+                actor_ref.send(to_msg(f.await), delay);
+            }),
+            TokioRuntimeOrHandle::Handle(handle) => handle.spawn(async move {
+                actor_ref.send(to_msg(f.await), delay);
+            }),
+        };
+    }
+
+    pub fn spawn_blocking_send<MsgT, HandlerT, R>(
+        &self,
+        f: impl FnOnce() -> R + Send + 'static,
+        to_msg: impl FnOnce(R) -> MsgT + Send + 'static,
+        mut actor_ref: AnActorRef<MsgT, HandlerT>,
+        delay: Option<Duration>,
+    ) where
+        MsgT: ActorMsg + 'static,
+        HandlerT: TypedHandler<MsgT = MsgT> + 'static,
         R: Send + 'static,
     {
-        match &self.value {
-            TokioRuntimeOrHandle::Runtime(runtime) => runtime.spawn(f),
-            TokioRuntimeOrHandle::Handle(handle) => handle.spawn(f),
+        match ::tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                log::debug!(
+                    "Tokio runtime '{}' performing blocking and then send inside an async context",
+                    self.name,
+                );
+                let _guard = handle.enter();
+                let actor_system_name = self.name.clone();
+                self.spawn_async(async move {
+                    match ::tokio::task::spawn_blocking(f).await {
+                        Ok(result) => actor_ref.send(to_msg(result), delay),
+                        Err(_) => log::error!(
+                            "Tokio runtime '{}': blocking task failed",
+                            actor_system_name
+                        ),
+                    };
+                });
+            }
+            Err(_) => {
+                log::debug!(
+                    "Tokio runtime '{}' performing blocking and then send outside of an async context",
+                    self.name,
+                );
+                actor_ref.send(to_msg(f()), delay)
+            }
         }
     }
 }
@@ -84,11 +144,11 @@ impl TokioRuntime {
 ///  as to avoid closing a new runtime from an async context (which panics).
 ///  If a runtime is created, it has multi-threaded support,
 ///  CPU-based thread pool size and all features enabled.
-pub fn get_tokio_runtime(name: impl Into<String>) -> TokioRuntime {
+pub fn get_async_runtime(name: impl Into<String>) -> AsyncRuntime {
     let runtime_name = Arc::new(name.into());
-    TokioRuntime {
+    AsyncRuntime {
         name: runtime_name.clone(),
-        value: match ::tokio::runtime::Handle::try_current() {
+        tokio: match ::tokio::runtime::Handle::try_current() {
             Ok(handle) => {
                 log::debug!("Reusing existing Tokyio runtime as '{}'", runtime_name,);
                 TokioRuntimeOrHandle::Handle(handle)

--- a/bftgrid-sim/Cargo.toml
+++ b/bftgrid-sim/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["Fabio Tudone <fabtud@gmail.com>"]
 
 [dependencies]
 bftgrid-core = { path = "../bftgrid-core" }
+tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread", "sync", "time", "net"] }
 rand_chacha = "0.9.0"
 dyn-clone = "1.0.19"

--- a/bftgrid-sim/src/lib.rs
+++ b/bftgrid-sim/src/lib.rs
@@ -11,8 +11,8 @@ use std::{
 };
 
 use bftgrid_core::{
-    ActorControl, ActorMsg, ActorRef, ActorSystem, P2PNetwork, P2PNetworkResult, TypedHandler,
-    UntypedHandlerBox,
+    ActorControl, ActorMsg, ActorRef, ActorSystem, P2PNetworkClient, P2PNetworkResult,
+    TypedHandler, UntypedHandlerBox,
 };
 use rand_chacha::{
     rand_core::{RngCore, SeedableRng},
@@ -537,7 +537,7 @@ impl ActorSystem for Simulation {
     }
 }
 
-impl P2PNetwork for Simulation {
+impl P2PNetworkClient for Simulation {
     fn attempt_send<MsgT, SerializerT>(
         &mut self,
         message: MsgT,

--- a/bftgrid-sim/src/lib.rs
+++ b/bftgrid-sim/src/lib.rs
@@ -171,6 +171,7 @@ pub struct Simulation {
     clock: Arc<Mutex<SimulatedClock>>,
     random: ChaCha8Rng,
     end_instant: Instant,
+    tokio_runtime: Arc<tokio::runtime::Runtime>,
 }
 
 impl Simulation {
@@ -185,6 +186,12 @@ impl Simulation {
             })),
             random: ChaCha8Rng::seed_from_u64(SEED),
             end_instant,
+            tokio_runtime: Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap(),
+            ),
         }
     }
 
@@ -465,6 +472,7 @@ impl Clone for Simulation {
             clock: self.clock.clone(),
             random: self.random.clone(),
             end_instant: self.end_instant,
+            tokio_runtime: self.tokio_runtime.clone(),
         }
     }
 }
@@ -534,6 +542,34 @@ impl ActorSystem for Simulation {
             actor_ref.name.clone(),
             Arc::new(Mutex::new(Some(Box::new(handler)))),
         );
+    }
+
+    fn spawn_async_send<MsgT, HandlerT, O>(
+        &self,
+        f: impl std::prelude::rust_2024::Future<Output = O> + Send + 'static,
+        to_msg: impl FnOnce(O) -> MsgT + Send + 'static,
+        mut actor_ref: bftgrid_core::AnActorRef<MsgT, HandlerT>,
+        delay: Option<Duration>,
+    ) where
+        MsgT: ActorMsg + 'static,
+        HandlerT: TypedHandler<MsgT = MsgT> + 'static,
+    {
+        let res = self.tokio_runtime.block_on(f);
+        actor_ref.send(to_msg(res), delay);
+    }
+
+    fn spawn_blocking_send<MsgT, HandlerT, R>(
+        &self,
+        f: impl FnOnce() -> R + Send + 'static,
+        to_msg: impl FnOnce(R) -> MsgT + Send + 'static,
+        mut actor_ref: bftgrid_core::AnActorRef<MsgT, HandlerT>,
+        delay: Option<Duration>,
+    ) where
+        MsgT: ActorMsg + 'static,
+        HandlerT: TypedHandler<MsgT = MsgT> + 'static,
+        R: Send + 'static,
+    {
+        actor_ref.send(to_msg(f()), delay);
     }
 }
 


### PR DESCRIPTION
- Support reusing Tokio runtimes, as well blocking on anything from any context; also, block on network sends so that actors can exit immediately afterwards if they wish
- Support integrating async and thread-blocking calls in actors